### PR TITLE
now there is no overflow of passwords box

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/index.css
+++ b/index.css
@@ -153,8 +153,9 @@ h1{
         font-size: 40px;
     }
     .page{
-        width: 100%;
-        height: 70%;
+        width: 100vw;
+        margin: 5%;
+        /* height: 70%; */
     }
     #Pass > div:hover .tooltip{
         visibility: hidden;


### PR DESCRIPTION
fixes #5 
![Screenshot from 2023-02-06 10-14-22](https://user-images.githubusercontent.com/119877487/216885560-6cca102c-6cfa-4b11-871c-3846f2d67e14.png)
Since there was the fixed height in the media query that's why the height is not expanding
I have removed the height from there not it adapts the height 
and some margin so that it look more beautiful